### PR TITLE
Add CI pipelines for KMP targets

### DIFF
--- a/.github/workflows/kmp-ci.yml
+++ b/.github/workflows/kmp-ci.yml
@@ -1,0 +1,71 @@
+name: Kotlin Multiplatform CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  android:
+    name: Android Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Assemble Android Debug
+        run: ./gradlew assembleDebug
+
+  ios:
+    name: iOS Tests
+    # macOS runner is required for iOS targets because Xcode tooling is only available on macOS.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Run iOS X64 Tests
+        run: ./gradlew iosX64Test
+
+  web:
+    name: Web Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build Web Distribution
+        run: ./gradlew jsBrowserDistribution
+
+  desktop:
+    name: Desktop Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build Desktop Jar
+        run: ./gradlew desktopJar

--- a/.github/workflows/kmp-ci.yml
+++ b/.github/workflows/kmp-ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./gradlew assembleDebug
 
   ios:
-    name: iOS Tests
+    name: iOS Frameworks
     # macOS runner is required for iOS targets because Xcode tooling is only available on macOS.
     runs-on: macos-latest
     steps:
@@ -35,11 +35,13 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Run iOS X64 Tests
-        run: ./gradlew iosX64Test
+      - name: Link iOS Simulator Framework
+        run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
+      - name: Link iOS Device Framework
+        run: ./gradlew :composeApp:linkDebugFrameworkIosArm64
 
   web:
-    name: Web Build
+    name: Web Development Run
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,11 +53,11 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build Web Distribution
-        run: ./gradlew jsBrowserDistribution
+      - name: Run Web Development Build
+        run: ./gradlew :composeApp:wasmJsBrowserDevelopmentRun
 
   desktop:
-    name: Desktop Build
+    name: Desktop Distribution
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -67,5 +69,5 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build Desktop Jar
-        run: ./gradlew desktopJar
+      - name: Package Desktop Distribution
+        run: ./gradlew :composeApp:packageDistributionForCurrentOS

--- a/.github/workflows/kmp-ci.yml
+++ b/.github/workflows/kmp-ci.yml
@@ -35,8 +35,6 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Link iOS Simulator Framework
-        run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
       - name: Link iOS Device Framework
         run: ./gradlew :composeApp:linkDebugFrameworkIosArm64
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,8 @@ android:
 ios:
   stage: ios
   script:
-    - ./gradlew iosX64Test
+    - ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
+    - ./gradlew :composeApp:linkDebugFrameworkIosArm64
   tags:
     - macos
   # Note: This job requires a macOS runner with Xcode installed to execute iOS builds.
@@ -31,10 +32,10 @@ web:
   stage: web
   image: gradle:8.5.0-jdk17
   script:
-    - ./gradlew jsBrowserDistribution
+    - ./gradlew :composeApp:wasmJsBrowserDevelopmentRun
 
 desktop:
   stage: desktop
   image: gradle:8.5.0-jdk17
   script:
-    - ./gradlew desktopJar
+    - ./gradlew :composeApp:packageDistributionForCurrentOS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ android:
 ios:
   stage: ios
   script:
-    - ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
     - ./gradlew :composeApp:linkDebugFrameworkIosArm64
   tags:
     - macos

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,40 @@
+stages:
+  - android
+  - ios
+  - web
+  - desktop
+
+default:
+  before_script:
+    - export GRADLE_USER_HOME="$CI_PROJECT_DIR/.gradle"
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .gradle/wrapper
+      - .gradle/caches
+
+android:
+  stage: android
+  image: gradle:8.5.0-jdk17
+  script:
+    - ./gradlew assembleDebug
+
+ios:
+  stage: ios
+  script:
+    - ./gradlew iosX64Test
+  tags:
+    - macos
+  # Note: This job requires a macOS runner with Xcode installed to execute iOS builds.
+
+web:
+  stage: web
+  image: gradle:8.5.0-jdk17
+  script:
+    - ./gradlew jsBrowserDistribution
+
+desktop:
+  stage: desktop
+  image: gradle:8.5.0-jdk17
+  script:
+    - ./gradlew desktopJar


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds Android, iOS, Web, and Desktop targets with Gradle caching and JDK 17
- introduce a GitLab CI configuration mirroring the target-specific stages and documenting the macOS requirement for iOS jobs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3c5eb723c8329913949bd792b48bf